### PR TITLE
Short array syntax reverted to array() for PHP5.3 compatibility.

### DIFF
--- a/src/PageBoost/HipChatV2/Contracts/RequestInterface.php
+++ b/src/PageBoost/HipChatV2/Contracts/RequestInterface.php
@@ -26,28 +26,28 @@ interface RequestInterface
      * @param array $queryParams
      * @return mixed
      */
-    public function get($uri, $queryParams = []);
+    public function get($uri, $queryParams = array());
 
     /**
      * @param       $uri
      * @param array $queryParams
      * @return mixed
      */
-    public function post($uri, $queryParams = []);
+    public function post($uri, $queryParams = array());
 
     /**
      * @param       $uri
      * @param array $queryParams
      * @return mixed
      */
-    public function put($uri, $queryParams = []);
+    public function put($uri, $queryParams = array());
 
     /**
      * @param       $uri
      * @param array $queryParams
      * @return mixed
      */
-    public function delete($uri, $queryParams = []);
+    public function delete($uri, $queryParams = array());
 
     /**
      * @param $response

--- a/src/PageBoost/HipChatV2/HttpClients/GuzzleV3.php
+++ b/src/PageBoost/HipChatV2/HttpClients/GuzzleV3.php
@@ -144,7 +144,11 @@ class GuzzleV3 implements RequestInterface
         $return->setRateLimit($rateLimitArray[0]);
         $return->setRateRemaining($rateRemainingArray[0]);
         $return->setRateReset($rateResetArray[0]);
-        $return->setData($response->json());
+        if (204 == $response->getStatusCode()) {
+            $return->setData("");
+        } else {
+            $return->setData($response->json());
+        }
         $return->setResponseCode($response->getStatusCode());
 
         return $return;


### PR DESCRIPTION
Just a change for PHP5.3 compatibility.
